### PR TITLE
Re-export element property.

### DIFF
--- a/src/rStats.js
+++ b/src/rStats.js
@@ -429,6 +429,7 @@ function rStats( settings ) {
     return function( id ) {
         if( id ) return _perf( id );
         return {
+            element: _base,
             update: _update
         }
     }


### PR DESCRIPTION
Thanks for making rStats! It's wonderful.

In our project we use the F8 key to hide and show the stats. Unfortunately, the container div is no longer being exported in the current build. This fixes that.

(cc @BKcore @mlogan)