### PR TITLE
Add white textshadow to alarm counter text for better readability

### DIFF
--- a/demo/rStats.css
+++ b/demo/rStats.css
@@ -1,4 +1,5 @@
 .alarm{
+    color: #b70000;
     text-shadow: 0 0 0 #b70000,
                  0 0 1px #fff,
                  0 0 1px #fff,

--- a/demo/rStats.css
+++ b/demo/rStats.css
@@ -1,3 +1,15 @@
+.alarm{
+    text-shadow: 0 0 0 #b70000,
+                 0 0 1px #fff,
+                 0 0 1px #fff,
+                 0 0 2px #fff,
+                 0 0 2px #fff,
+                 0 0 3px #fff,
+                 0 0 3px #fff,
+                 0 0 4px #fff,
+                 0 0 4px #fff;
+}
+
 .rs-base{
     position: absolute;
     z-index: 10000;

--- a/src/rStats.js
+++ b/src/rStats.js
@@ -194,8 +194,6 @@ window.rStats = function rStats ( settings ) {
             _graph = new Graph( _dom, _id, _def ),
             _started = false;
 
-        _dom.className = 'rs-counter-base';
-
         _spanId.className = 'rs-counter-id';
         _spanId.textContent = ( _def && _def.caption ) ? _def.caption : _id;
 
@@ -251,6 +249,8 @@ window.rStats = function rStats ( settings ) {
             var a = ( _def && ( ( _def.below && _value < _def.below ) || ( _def.over && _value > _def.over ) ) );
             _graph.draw( _value, a );
             _dom.style.color = a ? '#b70000' : '#ffffff';
+            _dom.className = a ? 'rs-counter-base alarm' : 'rs-counter-base';
+
         }
 
         function _frame () {

--- a/src/rStats.js
+++ b/src/rStats.js
@@ -248,7 +248,6 @@ window.rStats = function rStats ( settings ) {
             _spanValueText.nodeValue = Math.round( v * 100 ) / 100;
             var a = ( _def && ( ( _def.below && _value < _def.below ) || ( _def.over && _value > _def.over ) ) );
             _graph.draw( _value, a );
-            _dom.style.color = a ? '#b70000' : '#ffffff';
             _dom.className = a ? 'rs-counter-base alarm' : 'rs-counter-base';
 
         }


### PR DESCRIPTION
**Description:**

When a counter falls below the threshold, the alarm colored text (red) is hard to read behind the gray background. (https://github.com/aframevr/aframe/issues/1630)

![screen shot 2016-08-31 at 11 47 39 pm](https://cloud.githubusercontent.com/assets/7256178/18158022/60a39458-6fd5-11e6-9e8d-76f004513a72.png)

**Change Proposed:**

I'd like to propose adding a white text shadow to back the red text. This solution adds much more readability to the labels & values without intruding too much on the overall layout.

![screen shot 2016-08-31 at 11 32 32 pm](https://cloud.githubusercontent.com/assets/7256178/18158024/63ca0090-6fd5-11e6-843d-4f1719efb024.png)

To do this, I've created a new `.alarm` CSS class which holds the text-shadow & color property for counters below the threshold.
The text-shadow is dense and is made up of 9 levels of shadow to compose the overall red/white backing of the text.
I've replaced the `_dom.style.color=` assignment statement in `_draw` with `_dom.className=` to let the CSS handle the color instead of inline through javascript.

This issue & solution has also been discussed in https://github.com/aframevr/aframe/issues/1630 & https://github.com/aframevr/aframe/pull/1880


